### PR TITLE
Hotfix 4.2.5: corrige tsconfig e documentação

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,15 +15,15 @@ Biblioteca TypeScript publicada no npm com validadores, conversores e abstraçõ
 
 ## Módulos existentes
 
-| Módulo    | Estende | Responsabilidade principal                          |
-|-----------|---------|-----------------------------------------------------|
-| KlString  | String  | Máscaras/validação CPF/CNPJ, camelCase, base64      |
-| KlNumber  | Number  | Formatação monetária, números aleatórios            |
-| KlDate    | Date    | Formatação, fuso, add/sub, feriados (BR)            |
-| KlTime    | Date    | Manipulação de horários                             |
-| KlArray   | Array   | split, orderBy, shuffle, clearEmptyValues           |
-| KlDelay   | —       | `delay()` / `KlDelay.waitFor()` assíncrono          |
-| KlCron    | —       | Medição de duração de execução                      |
+| Módulo   | Estende | Responsabilidade principal                     |
+| -------- | ------- | ---------------------------------------------- |
+| KlString | String  | Máscaras/validação CPF/CNPJ, camelCase, base64 |
+| KlNumber | Number  | Formatação monetária, números aleatórios       |
+| KlDate   | Date    | Formatação, fuso, add/sub, feriados (BR)       |
+| KlTime   | Date    | Manipulação de horários                        |
+| KlArray  | Array   | split, orderBy, shuffle, clearEmptyValues      |
+| KlDelay  | —       | `delay()` / `KlDelay.waitFor()` assíncrono     |
+| KlCron   | —       | Medição de duração de execução                 |
 
 ## Padrões de implementação
 
@@ -31,7 +31,7 @@ Biblioteca TypeScript publicada no npm com validadores, conversores e abstraçõ
 
 - Prefixo `Kl` em classes, tipos e enums (`KlDateDateType`, `KlDateDayEnum`).
 - Arquivo de teste colocado ao lado do fonte: `KlString.spec.ts`.
-- Imports internos usam caminhos relativos (`./KlNumber`, `../types/...`). O alias `@/*` → `./src/*` existe no `tsconfig`, mas o código atual prefere relativos.
+- Imports internos usam caminhos relativos (`./KlNumber`, `../types/...`).
 
 ### Imutabilidade vs mutação
 
@@ -57,35 +57,55 @@ Ao adicionar dependência, avalie se faz sentido manter uma versão **light** se
 
 1. Criar `src/Kl{Nome}.ts` com a classe estendendo o tipo nativo adequado (ou classe utilitária, como `KlCron`).
 2. Exportar funções utilitárias no mesmo arquivo, delegando à classe.
-3. Criar `src/Kl{Nome}.spec.ts` com testes Vitest (`describe`/`it`/`expect`).
+3. Criar `src/Kl{Nome}.spec.ts` com testes Bun (`describe`/`it`/`expect`).
 4. Adicionar `export * from "./Kl{Nome}"` em `src/index.ts`.
 5. Atualizar `README.md` com seção do novo módulo (métodos + exemplos).
 6. Se o módulo tiver variante sem dependência pesada, considerar `src/light/Kl{Nome}.ts` e atualizar `src/light/index.ts`.
 
 ## Testes
 
-- Framework: **Vitest** com globals habilitados (`describe`, `it`, `expect` sem import).
-- Config: `vitest.config.mts` com `vite-tsconfig-paths`.
-- Executar: `npm test` (CI) ou `npm run test:watch` (desenvolvimento).
+- Framework: **Bun test** nativo (`describe`, `it`, `expect` sem import).
+- Config: `bunfig.toml` com `root = "src"`.
+- Executar: `bun run test` (CI) ou `bun run test:watch` (desenvolvimento).
 - Cobrir métodos da classe e funções utilitárias exportadas.
 - Usar dados reais quando possível (ex.: CPF/CNPJ válidos); `validation-br/dist/cnpj` oferece `fake()` nos testes.
 
+## Pull requests e versionamento
+
+Toda PR para `main` **deve incluir bump de versão** no `package.json`, escolhendo o comando conforme o tipo de mudança (SemVer):
+
+| Tipo de mudança                  | Comando                  | Exemplo de uso            |
+| -------------------------------- | ------------------------ | ------------------------- |
+| Correção / deps / tooling        | `bun run deploy:hotfix`  | patch (`4.2.4` → `4.2.5`) |
+| Nova funcionalidade (compatível) | `bun run deploy:feature` | minor (`4.2.4` → `4.3.0`) |
+| Breaking change na API pública   | `bun run deploy:release` | major (`4.2.4` → `5.0.0`) |
+
+Cada script roda os testes antes de versionar. Na PR, use `--no-git-tag-version` para atualizar só o `package.json` sem tag/push automático:
+
+```bash
+bun run test && bun pm version patch --no-git-tag-version   # equiv. deploy:hotfix
+bun run test && bun pm version minor --no-git-tag-version   # equiv. deploy:feature
+bun run test && bun pm version major --no-git-tag-version   # equiv. deploy:release
+```
+
+Inclua a alteração de versão no mesmo commit ou branch da PR antes de abrir/atualizar.
+
 ## Build e publicação
 
-- `npm run build` executa `tsc` e copia `package.json` (sem scripts/devDependencies), `README.md` e `LICENSE` para `dist/`.
+- `bun run build` executa `tsc` e copia `package.json` (sem scripts/devDependencies), `README.md` e `LICENSE` para `dist/`.
 - O pacote publicado sai de `dist/`; consumidores importam por subpath:
   ```typescript
   import { KlString, maskCpf } from "@koalarx/utils/KlString";
   import { delay } from "@koalarx/utils/KlDelay";
   ```
 - `prepublishOnly` roda os testes; `preversion` roda o lint.
-- Node mínimo: `^20.18.0` (ver `engines` no `package.json`).
+- Runtimes suportados: Node `>=20.18.0` e Bun `>=1.2.0` (ver `engines` no `package.json`).
 
 ## Qualidade de código
 
 - TypeScript com `strict: true`; `noImplicitAny: false` (legado).
-- ESLint: `@rocketseat/eslint-config/node` + Prettier.
-- Lint/format: `npm run lint` (Prettier + ESLint fix em `src/**/*`).
+- ESLint flat config (`eslint.config.mts`) com `typescript-eslint` + Prettier.
+- Lint/format: `bun run lint` (Prettier + ESLint fix em `src/**/*.ts`).
 - Não commitar `dist/` — gerado no build/CI.
 - Evitar `any` desnecessário; `@typescript-eslint/no-explicit-any` está desligado, mas prefira tipos explícitos.
 - Variáveis não usadas são erro (`@typescript-eslint/no-unused-vars`).
@@ -101,14 +121,17 @@ Ao adicionar dependência, avalie se faz sentido manter uma versão **light** se
 - Não quebrar a API pública sem bump de versão major.
 - Não adicionar dependências sem avaliar impacto no bundle e na variante light.
 - Não remover JSDoc ao refatorar.
-- Não usar frameworks de teste além do Vitest.
+- Não usar frameworks de teste além do Bun test.
 - Não alterar o fluxo de build (`tsc` → `dist/`) sem atualizar o workflow `.github/workflows/npm-publish.yml`.
 
 ## Comandos úteis
 
 ```bash
-npm test              # rodar testes
-npm run test:watch    # testes em modo watch
-npm run lint          # formatar e corrigir lint
-npm run build         # compilar para dist/
+bun run test              # rodar testes
+bun run test:watch        # testes em modo watch
+bun run lint              # formatar e corrigir lint
+bun run build             # compilar para dist/
+bun run deploy:hotfix     # patch + testes (publicação)
+bun run deploy:feature    # minor + testes (publicação)
+bun run deploy:release    # major + testes (publicação)
 ```

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,6 +33,7 @@
     "editor.formatOnSave": true
   },
   "typescript.suggest.autoImports": true,
+  "typescript.tsdk": "node_modules/typescript/lib",
   "terminal.integrated.env.osx": {
     "FIG_NEW_SESSION": "1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/utils",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "engines": {
     "node": ">=20.18.0",
     "bun": ">=1.2.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,6 @@
     "sourceMap": false,
     "outDir": "./dist",
     "rootDir": "./src",
-    "baseUrl": "./",
-    "paths": {
-      "@/*": ["./src/*"]
-    },
-    "ignoreDeprecations": "6.0",
     "skipLibCheck": true,
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
## Summary
- Sobe versão para **4.2.5** (patch)
- Remove `baseUrl`, `paths` e `ignoreDeprecations` do `tsconfig.json` (corrige erro do editor com TS 5.x)
- Configura `typescript.tsdk` no VS Code para usar o TypeScript 6 do projeto
- Atualiza `copilot-instructions.md` com stack Bun, ESLint flat config e regra de versionamento em PRs

## Test plan
- [x] `bun run test` — 44 testes passando
- [x] `bun run build` — compilação OK
- [x] `bun run lint` — sem erros


Made with [Cursor](https://cursor.com)