### PR TITLE
Hotfix 4.2.6 — republica após Dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koalarx/utils",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "engines": {
     "node": ">=20.18.0",
     "bun": ">=1.2.0"


### PR DESCRIPTION
## Summary
- Sobe a versão para **4.2.6** para republicar no npm após o merge do #35 (Dependabot), que falhou ao tentar republicar `4.2.5`

## Test plan
- [x] `bun run test`
- [x] `bun run lint` (via preversion)
- [ ] Confirmar publish do workflow NPM PUBLISH após o merge


Made with [Cursor](https://cursor.com)