### PR TITLE
Atualiza o sitemap e as regras do robots.txt para melhor controle de …

### DIFF
--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -49,6 +49,5 @@ Thumbs.db
 # Generated markdown for LLMs (synced from libs/doc/markdown on build)
 /public/markdown/
 
-# Generated at build time (see scripts/post-build.mjs and scripts/build-doc-manifest.mjs)
-/public/sitemap.xml
+# Generated at build time (see scripts/build-doc-manifest.mjs)
 /prerender-routes.txt

--- a/docs/site/public/robots.txt
+++ b/docs/site/public/robots.txt
@@ -1,4 +1,11 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://nest.koalarx.com/sitemap.xml
+# Raw markdown and LLM indexes are for agents/tools, not search results.
+Disallow: /markdown/
+Disallow: /llm.txt
+Disallow: /llm-en.txt
+Disallow: /llms.txt
+Disallow: /llms-en.txt
+
+Sitemap: https://utils.koalarx.com/sitemap.xml

--- a/docs/site/public/sitemap.xml
+++ b/docs/site/public/sitemap.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://utils.koalarx.com/pt/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/intro/visao-geral/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/intro/visao-geral/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/intro/overview/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/intro/visao-geral/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/inicio/instalacao/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/inicio/instalacao/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/getting-started/installation/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/inicio/instalacao/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/inicio/frontend-vs-backend/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/inicio/frontend-vs-backend/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/getting-started/frontend-vs-backend/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/inicio/frontend-vs-backend/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/core/kl-string/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-string/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-string/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-string/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/core/kl-number/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-number/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-number/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-number/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/core/kl-date/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-date/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-date/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-date/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/core/kl-time/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-time/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-time/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-time/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/core/kl-array/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-array/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-array/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-array/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/core/kl-delay-cron/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-delay-cron/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-delay-cron/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-delay-cron/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/core/holidays/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/holidays/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/holidays/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/holidays/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/operators/visao-geral/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/operators/visao-geral/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/operators/overview/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/operators/visao-geral/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/operators/catalogo/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/operators/catalogo/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/operators/catalog/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/operators/catalogo/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/prototypes/visao-geral/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/prototypes/visao-geral/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/prototypes/overview/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/prototypes/visao-geral/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/prototypes/catalogo/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/prototypes/catalogo/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/prototypes/catalog/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/prototypes/catalogo/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/guias/para-llms/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/guias/para-llms/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/guides/for-llms/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/guias/para-llms/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/pt/docs/guias/migracao-5/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/guias/migracao-5/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/guides/migration-5/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/guias/migracao-5/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/intro/overview/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/intro/visao-geral/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/intro/overview/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/intro/visao-geral/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/getting-started/installation/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/inicio/instalacao/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/getting-started/installation/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/inicio/instalacao/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/getting-started/frontend-vs-backend/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/inicio/frontend-vs-backend/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/getting-started/frontend-vs-backend/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/inicio/frontend-vs-backend/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/core/kl-string/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-string/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-string/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-string/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/core/kl-number/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-number/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-number/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-number/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/core/kl-date/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-date/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-date/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-date/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/core/kl-time/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-time/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-time/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-time/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/core/kl-array/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-array/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-array/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-array/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/core/kl-delay-cron/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/kl-delay-cron/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/kl-delay-cron/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/kl-delay-cron/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/core/holidays/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/core/holidays/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/core/holidays/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/core/holidays/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/operators/overview/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/operators/visao-geral/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/operators/overview/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/operators/visao-geral/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/operators/catalog/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/operators/catalogo/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/operators/catalog/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/operators/catalogo/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/prototypes/overview/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/prototypes/visao-geral/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/prototypes/overview/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/prototypes/visao-geral/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/prototypes/catalog/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/prototypes/catalogo/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/prototypes/catalog/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/prototypes/catalogo/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/guides/for-llms/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/guias/para-llms/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/guides/for-llms/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/guias/para-llms/" />
+  </url>
+  <url>
+    <loc>https://utils.koalarx.com/en/docs/guides/migration-5/</loc>
+    <xhtml:link rel="alternate" hreflang="pt-BR" href="https://utils.koalarx.com/pt/docs/guias/migracao-5/" />
+    <xhtml:link rel="alternate" hreflang="en" href="https://utils.koalarx.com/en/docs/guides/migration-5/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://utils.koalarx.com/pt/docs/guias/migracao-5/" />
+  </url>
+</urlset>

--- a/docs/site/scripts/generate-sitemap.mjs
+++ b/docs/site/scripts/generate-sitemap.mjs
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SITE_URL = 'https://utils.koalarx.com';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const siteRoot = path.resolve(__dirname, '..');
+const manifestPath = path.join(siteRoot, 'src/generated/docs-manifest.json');
+const publicSitemapPath = path.join(siteRoot, 'public/sitemap.xml');
+
+/** GitHub Pages 301s bare paths to trailing-slash dirs; sitemap must list final URLs. */
+function withTrailingSlash(route) {
+  if (!route || route === '/') return '/';
+  return route.endsWith('/') ? route : `${route}/`;
+}
+
+function absoluteUrl(route) {
+  const normalized = withTrailingSlash(route);
+  return normalized === '/' ? `${SITE_URL}/` : `${SITE_URL}${normalized}`;
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+function xhtmlAlternates(alternates) {
+  return alternates
+    .map(
+      ([hreflang, href]) =>
+        `    <xhtml:link rel="alternate" hreflang="${hreflang}" href="${escapeXml(href)}" />`,
+    )
+    .join('\n');
+}
+
+export function buildSitemapEntries(manifest) {
+  const entries = [];
+
+  // Omit `/` — prerender meta-refresh → `/pt` → GH Pages 301 `/pt/` ("Redirect error").
+  for (const locale of manifest.supportedLocales) {
+    const alternateHome = locale === 'pt' ? '/en' : '/pt';
+    const homeLoc = absoluteUrl(`/${locale}`);
+    entries.push({
+      loc: homeLoc,
+      alternates: [
+        ['pt-BR', absoluteUrl('/pt')],
+        ['en', absoluteUrl('/en')],
+        ['x-default', absoluteUrl('/pt')],
+      ],
+    });
+
+    for (const doc of manifest.locales[locale].docs) {
+      const loc = absoluteUrl(doc.route);
+      const alternate = doc.alternateRoute
+        ? absoluteUrl(doc.alternateRoute)
+        : absoluteUrl(alternateHome);
+      const ptHref = locale === 'pt' ? loc : alternate;
+      const enHref = locale === 'en' ? loc : alternate;
+
+      entries.push({
+        loc,
+        alternates: [
+          ['pt-BR', ptHref],
+          ['en', enHref],
+          ['x-default', ptHref],
+        ],
+      });
+    }
+  }
+
+  const seen = new Set();
+  return entries.filter((entry) => {
+    if (seen.has(entry.loc)) return false;
+    seen.add(entry.loc);
+    return true;
+  });
+}
+
+export function buildSitemapXml(entries) {
+  const urls = entries
+    .map((entry) => {
+      const links = xhtmlAlternates(entry.alternates);
+      return `  <url>\n    <loc>${escapeXml(entry.loc)}</loc>\n${links}\n  </url>`;
+    })
+    .join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">',
+    urls,
+    '</urlset>',
+    '',
+  ].join('\n');
+}
+
+export function writeSitemap(manifest, targets) {
+  const xml = buildSitemapXml(buildSitemapEntries(manifest));
+  for (const target of targets) {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, xml);
+    console.log(`Sitemap gerado → ${target}`);
+  }
+  return xml;
+}
+
+export function generatePublicSitemap() {
+  if (!fs.existsSync(manifestPath)) {
+    console.warn('Manifest não encontrado; sitemap.xml não foi gerado.');
+    return false;
+  }
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  writeSitemap(manifest, [publicSitemapPath]);
+  return true;
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  if (!generatePublicSitemap()) process.exit(1);
+}

--- a/docs/site/scripts/post-build.mjs
+++ b/docs/site/scripts/post-build.mjs
@@ -1,39 +1,21 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { writeSitemap } from './generate-sitemap.mjs';
 
-const SITE_URL = "https://utils.koalarx.com";
 const outputDir = path.resolve('dist/site/browser');
 const manifestPath = path.resolve('src/generated/docs-manifest.json');
 const indexFile = path.join(outputDir, 'index.html');
 const notFoundFile = path.join(outputDir, '404.html');
 const sitemapFile = path.join(outputDir, 'sitemap.xml');
+const publicSitemapFile = path.resolve('public/sitemap.xml');
 
-function buildSitemapRoutes(manifest) {
-  return [
-    '/',
-    ...manifest.supportedLocales.flatMap((locale) => [
-      `/${locale}`,
-      ...manifest.locales[locale].docs.map((doc) => doc.route),
-    ]),
-  ];
-}
-
-function buildSitemapXml(routes) {
-  const uniqueRoutes = [...new Set(routes.filter(Boolean))];
-  const urls = uniqueRoutes
-    .map((route) => {
-      const loc = route === '/' ? SITE_URL : `${SITE_URL}${route}`;
-      return `  <url>\n    <loc>${loc}</loc>\n  </url>`;
-    })
-    .join('\n');
-
-  return [
-    '<?xml version="1.0" encoding="UTF-8"?>',
-    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-    urls,
-    '</urlset>',
-    '',
-  ].join('\n');
+/** Point Angular prerender soft-redirect at the final GH Pages URL (trailing slash). */
+function fixRootRedirect(html) {
+  return html
+    .replaceAll('url=/pt"', 'url=/pt/"')
+    .replaceAll("url=/pt'", "url=/pt/'")
+    .replaceAll('href="/pt"', 'href="/pt/"')
+    .replaceAll('>/pt</a>', '>/pt/</a>');
 }
 
 if (!fs.existsSync(indexFile)) {
@@ -41,7 +23,9 @@ if (!fs.existsSync(indexFile)) {
   process.exit(1);
 }
 
-fs.copyFileSync(indexFile, notFoundFile);
+const indexHtml = fixRootRedirect(fs.readFileSync(indexFile, 'utf8'));
+fs.writeFileSync(indexFile, indexHtml);
+fs.writeFileSync(notFoundFile, indexHtml);
 
 for (const file of fs.readdirSync(outputDir)) {
   if (file.endsWith('.map')) {
@@ -51,8 +35,7 @@ for (const file of fs.readdirSync(outputDir)) {
 
 if (fs.existsSync(manifestPath)) {
   const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-  fs.writeFileSync(sitemapFile, buildSitemapXml(buildSitemapRoutes(manifest)));
-  console.log(`Sitemap gerado → ${sitemapFile}`);
+  writeSitemap(manifest, [sitemapFile, publicSitemapFile]);
 } else {
   console.warn('Manifest não encontrado; sitemap.xml não foi gerado.');
 }

--- a/docs/site/src/app/core/config/site-seo.ts
+++ b/docs/site/src/app/core/config/site-seo.ts
@@ -2,8 +2,17 @@ export const SITE_URL = "https://utils.koalarx.com";
 export const SITE_NAME = "@koalarx/utils";
 export const DEFAULT_OG_IMAGE = `${SITE_URL}/logo.svg`;
 
+/**
+ * Absolute URL for the docs site.
+ * Page paths get a trailing slash (GitHub Pages serves dirs as `/en/`, not `/en`).
+ * File paths (e.g. `.md`, `.txt`) keep their exact path.
+ */
 export function absoluteSiteUrl(path: string) {
-  if (!path || path === "/") return SITE_URL;
+  if (!path || path === "/") return `${SITE_URL}/`;
   const normalized = path.startsWith("/") ? path : `/${path}`;
-  return `${SITE_URL}${normalized}`;
+  if (/\.[a-z0-9]+$/i.test(normalized)) {
+    return `${SITE_URL}${normalized}`;
+  }
+  const withSlash = normalized.endsWith("/") ? normalized : `${normalized}/`;
+  return `${SITE_URL}${withSlash}`;
 }

--- a/docs/site/src/index.html
+++ b/docs/site/src/index.html
@@ -11,10 +11,10 @@
     />
     <meta name="robots" content="index, follow" />
     <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large" />
-    <link rel="canonical" href="https://utils.koalarx.com/" />
+    <link rel="canonical" href="https://utils.koalarx.com/pt/" />
     <meta property="og:site_name" content="@koalarx/utils" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://utils.koalarx.com/" />
+    <meta property="og:url" content="https://utils.koalarx.com/pt/" />
     <meta property="og:title" content="@koalarx/utils — utilitários TypeScript do ecossistema Koala" />
     <meta
       property="og:description"

--- a/scripts/build-doc-manifest.mjs
+++ b/scripts/build-doc-manifest.mjs
@@ -240,3 +240,8 @@ console.log(
 );
 console.log(`Versão da doc sincronizada: v${appVersion}`);
 console.log(`Markdown publicado: ${markdownFiles} arquivos`);
+
+const { generatePublicSitemap } = await import(
+  "../docs/site/scripts/generate-sitemap.mjs"
+);
+generatePublicSitemap();


### PR DESCRIPTION
…indexação. Remove a geração do sitemap no build e ajusta URLs canônicas para incluir o trailing slash. Melhora a função de URL absoluta para garantir a formatação correta. Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-site SEO, robots, and build scripts only; no runtime library or auth/data changes.
> 
> **Overview**
> Aligns docs SEO with **utils.koalarx.com** and GitHub Pages’ trailing-slash URLs, and keeps agent-only content out of search indexes.
> 
> **Sitemap:** New `generate-sitemap.mjs` builds XML from the docs manifest with trailing slashes, `xhtml:link` **hreflang** pairs (pt-BR / en / x-default), and no bare `/` entry (avoids redirect chains). The same generator runs from `build-doc-manifest.mjs` and `post-build.mjs`; `public/sitemap.xml` is checked in and no longer treated as build-only in `.gitignore`.
> 
> **robots.txt:** Sitemap URL points to utils.koalarx.com; **Disallow** rules block `/markdown/` and LLM index files (`llm*.txt`, `llms*.txt`).
> 
> **Canonical URLs:** Root `index.html` canonical/OG URLs target `/pt/`; `absoluteSiteUrl` adds trailing slashes for page paths but not file extensions; post-build rewrites prerendered root redirects from `/pt` to `/pt/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f0eac1a845c5a2f745526e109430d76eb8eea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->